### PR TITLE
Precautions checkbox is always set to false 

### DIFF
--- a/src/ibcontroller/ConfigureTwsApiPortTask.java
+++ b/src/ibcontroller/ConfigureTwsApiPortTask.java
@@ -50,10 +50,9 @@ class ConfigureTwsApiPortTask implements Runnable{
     private void configure(final JDialog configDialog, final int portNumber) {
         try {
             Utils.logToConsole("Performing port configuration");
-            
-            if (!Utils.selectConfigSection(configDialog, new String[] {"API","Settings"}))
-                // older versions of TWS don't have the Settings node below the API node
-                Utils.selectConfigSection(configDialog, new String[] {"API"});
+
+            // older versions of TWS don't have the Settings node below the API node
+            Utils.selectConfigSection(configDialog, new String[] {"API","Settings"}, new String[] {"API"});
 
             Component comp = SwingUtils.findComponent(configDialog, "Socket port");
             if (comp == null) throw new IBControllerException("could not find socket port component");

--- a/src/ibcontroller/EnableApiTask.java
+++ b/src/ibcontroller/EnableApiTask.java
@@ -58,10 +58,9 @@ class EnableApiTask implements Runnable{
     private void configureAPI(JDialog configDialog) {
         try {
             Utils.logToConsole("Doing ENABLEAPI configuration");
-            
-            if (!Utils.selectConfigSection(configDialog, new String[] {"API","Settings"}))
-                // older versions of TWS don't have the Settings node below the API node
-                Utils.selectConfigSection(configDialog, new String[] {"API"});
+
+            // older versions of TWS don't have the Settings node below the API node
+            Utils.selectConfigSection(configDialog, new String[] {"API","Settings"}, new String[] {"API"});
 
             JCheckBox cb = SwingUtils.findCheckBox(configDialog, "Enable ActiveX and Socket Clients");
             if (cb == null) throw new IBControllerException("could not find Enable ActiveX checkbox");

--- a/src/ibcontroller/Utils.java
+++ b/src/ibcontroller/Utils.java
@@ -188,6 +188,26 @@ class Utils {
         return true;
     }
 
+    /**
+     * Convenient method for specifying fallback path if configuration path is not present
+     * @param configDialog
+     * the Global Configuration dialog
+     * @param path
+     * the path to the required configuration section in the Global Configuration dialog
+     * @param fallbackPath
+     * fallback path to the required configuration section in the Global Configuration dialog
+     * @return
+     * true if the specified section can be found; otherwise false
+     * @throws IBControllerException
+     * a UI component could not be found
+     * @throws IllegalStateException
+     * the method has not been called on the SWing event dispatch thread
+     */
+    static boolean selectConfigSection(final JDialog configDialog, final String[] path, final String[] fallbackPath) throws IBControllerException, IllegalStateException {
+        return selectConfigSection(configDialog, path) ||
+               selectConfigSection(configDialog, fallbackPath);
+    }
+
     static void showTradesLogWindow() {
             MyCachedThreadPool.getInstance().execute(new Runnable () {
                 @Override public void run() {invokeMenuItem(MainWindowManager.mainWindowManager().getMainWindow(), new String[] {"Account", "Trade Log"});}


### PR DESCRIPTION
ConfigureApiSettingTask should be capable to set also 'Bypass Order precautions' checkbox. Currently 'bypassOrderPrecautions' setting is disregarded and in both cases it is set to _false_. I noticed how code checks not only 'bypassOrderPrecautions' setting but also if checkbox is currently checked or not - which I think is redundant or maybe can be even harmful. Same applies to 'Read-Only API' checkbox. 

What has been done:

- Fixed 'bypassOrderPrecautions' checkbox setting
- Moved similar/same code into functions to make it more readable (I hope)
- Create new static 'selectConfigSection' that accepts fallback for older versions - also replaced places where can we use that function