### PR TITLE
Login does not work for latest TWS in version 974

### DIFF
--- a/src/ibcontroller/AbstractLoginHandler.java
+++ b/src/ibcontroller/AbstractLoginHandler.java
@@ -80,6 +80,11 @@ public abstract class AbstractLoginHandler implements WindowHandler {
                                             final String value) throws IBControllerException {
         if (! SwingUtils.setTextField(window, credentialIndex, value)) throw new IBControllerException(credentialName);
     }
+
+    protected final void setIBApiCredentials(Window window, int firstIndex) throws IBControllerException {
+        setCredential(window, "IBAPI user name", firstIndex, LoginManager.loginManager().IBAPIUserName());
+        setCredential(window, "IBAPI password", firstIndex + 1, LoginManager.loginManager().IBAPIPassword());
+    }
     
     protected final void setTradingModeCombo(final Window window) {
         if (SwingUtils.findLabel(window, "Trading Mode") != null)  {

--- a/src/ibcontroller/AbstractLoginHandler.java
+++ b/src/ibcontroller/AbstractLoginHandler.java
@@ -54,12 +54,12 @@ public abstract class AbstractLoginHandler implements WindowHandler {
     public abstract boolean recogniseWindow(Window window);
     
     private void doLogin(final Window window) throws IBControllerException {
-        if (SwingUtils.findButton(window, "Login") == null) throw new IBControllerException("Login button");
+        if (SwingUtils.findButton(window, "Login", "Log In", "Paper Log In") == null) throw new IBControllerException("Login button");
 
         GuiDeferredExecutor.instance().execute(new Runnable() {
             @Override
             public void run() {
-                SwingUtils.clickButton(window, "Login");
+                SwingUtils.clickButton(window, "Login", "Log In", "Paper Log In");
             }
         });
     }

--- a/src/ibcontroller/AbstractLoginHandler.java
+++ b/src/ibcontroller/AbstractLoginHandler.java
@@ -99,6 +99,19 @@ public abstract class AbstractLoginHandler implements WindowHandler {
                     tradingModeCombo.setSelectedItem("Paper Trading");
                 }
             }
+        } else {
+            setTradingModeComboAfter974(window);
+        }
+    }
+
+    // There is new component for choosing trading mode made from toggle buttons in TWS version 974
+    private void setTradingModeComboAfter974(final Window window) {
+        if (SwingUtils.findToggleButton(window, "Live Trading") != null) {
+            String tradingMode = TradingModeManager.tradingModeManager().getTradingMode();
+            boolean isLiveTradingMode = tradingMode.equalsIgnoreCase(TradingModeManager.TRADING_MODE_LIVE);
+            if (SwingUtils.setToggleButtonSelected(window, isLiveTradingMode ? "Live Trading" : "Paper Trading")) {
+                Utils.logToConsole("Setting Trading mode = " + tradingMode);
+            }
         }
     }
     

--- a/src/ibcontroller/GatewayLoginFrameHandler.java
+++ b/src/ibcontroller/GatewayLoginFrameHandler.java
@@ -20,7 +20,7 @@ package ibcontroller;
 
 import java.awt.Window;
 import javax.swing.JFrame;
-import javax.swing.JRadioButton;
+import javax.swing.JToggleButton;
 
 final class GatewayLoginFrameHandler extends AbstractLoginHandler {
     
@@ -29,7 +29,7 @@ final class GatewayLoginFrameHandler extends AbstractLoginHandler {
         if (! (window instanceof JFrame)) return false;
 
         return (SwingUtils.titleContains(window, "IB Gateway") &&
-               (SwingUtils.findButton(window, "Login") != null));
+               (SwingUtils.findButton(window, "Login", "Log In", "Paper Log In") != null));
     }
 
     @Override
@@ -87,15 +87,19 @@ final class GatewayLoginFrameHandler extends AbstractLoginHandler {
         if (Settings.settings().getBoolean("FIX", false)) {
             setCredential(window, "FIX user name", 0, LoginManager.loginManager().FIXUserName());
             setCredential(window, "FIX password", 1, LoginManager.loginManager().FIXPassword());
-            setCredential(window, "IBAPI user name", 3, LoginManager.loginManager().IBAPIUserName());
-            setCredential(window, "IBAPI password", 4, LoginManager.loginManager().IBAPIPassword());
+            setIBApiCredentialsOnFIX(window);
         } else {
-            setCredential(window, "IBAPI user name", 0, LoginManager.loginManager().IBAPIUserName());
-            setCredential(window, "IBAPI password", 1, LoginManager.loginManager().IBAPIPassword());
+            setIBApiCredentials(window, 0);
         }
         return true;
     }
-    
+
+    private void setIBApiCredentialsOnFIX(Window window) throws IBControllerException {
+        boolean isBefore974 = SwingUtils.findRadioButton(window, "FIX CTCI") != null;
+        // There is no additional text field between credentials text fields pairs after 974
+        setIBApiCredentials(window, isBefore974 ? 3 : 2);
+    }
+
     private void selectGatewayMode(Window window) throws IBControllerException {
         if (Settings.settings().getBoolean("FIX", false)) {
             switchToFIX(window);
@@ -105,15 +109,17 @@ final class GatewayLoginFrameHandler extends AbstractLoginHandler {
     }
     
     private void switchToFIX(Window window) throws IBControllerException {
-        JRadioButton button = SwingUtils.findRadioButton(window, "FIX CTCI");
-        if (button == null) throw new IBControllerException("FIX CTCI radio button");
+        // JRadioButton is subclass of JToggleButton so it should work for older radio buttons too
+        JToggleButton button = SwingUtils.findToggleButton(window, "FIX CTCI");
+        if (button == null) throw new IBControllerException("FIX CTCI button");
         
         if (! button.isSelected()) button.doClick();
     }
     
     private void switchToIBAPI(Window window) throws IBControllerException {
-        JRadioButton button = SwingUtils.findRadioButton(window, "IB API");
-        if (button == null) button = SwingUtils.findRadioButton(window, "TWS/API") ;
+        // JRadioButton is subclass of JToggleButton so it should work for older radio buttons too
+        JToggleButton button = SwingUtils.findToggleButton(window, "IB API");
+        if (button == null) button = SwingUtils.findToggleButton(window, "TWS/API") ;
         if (button == null) throw new IBControllerException("IB API radio button");
         
         if (! button.isSelected()) button.doClick();

--- a/src/ibcontroller/LoginFrameHandler.java
+++ b/src/ibcontroller/LoginFrameHandler.java
@@ -32,7 +32,7 @@ final class LoginFrameHandler extends AbstractLoginHandler {
         // entitled Login, when it's trying to reconnect
         return ((SwingUtils.titleEquals(window, "New Login") ||
                 SwingUtils.titleEquals(window, "Login")) &&
-                SwingUtils.findButton(window, "Login") != null);
+                SwingUtils.findButton(window, "Login", "Log In", "Paper Log In") != null);
     }
 
     @Override

--- a/src/ibcontroller/LoginFrameHandler.java
+++ b/src/ibcontroller/LoginFrameHandler.java
@@ -65,8 +65,7 @@ final class LoginFrameHandler extends AbstractLoginHandler {
     
     @Override
     protected final boolean setFields(Window window, int eventID) throws IBControllerException {
-        setCredential(window, "IBAPI user name", 0, LoginManager.loginManager().IBAPIUserName());
-        setCredential(window, "IBAPI password", 1, LoginManager.loginManager().IBAPIPassword());
+        setIBApiCredentials(window, 0);
         return true;
     }
     

--- a/src/ibcontroller/LoginFrameHandler.java
+++ b/src/ibcontroller/LoginFrameHandler.java
@@ -39,6 +39,9 @@ final class LoginFrameHandler extends AbstractLoginHandler {
     protected final boolean initialise(final Window window, int eventID) throws IBControllerException {
         setTradingModeCombo(window);
 
+        // Ensure store settings on server is visible after 974
+        SwingUtils.clickButton(window, "More Options");
+
         final String STORE_SETTINGS_ON_SERVER_CHECKBOX = "Use/store settings on server";
         if (! SwingUtils.setCheckBoxSelected(
                 window,

--- a/src/ibcontroller/SwingUtils.java
+++ b/src/ibcontroller/SwingUtils.java
@@ -22,6 +22,8 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.Window;
 import java.awt.event.WindowEvent;
+import java.util.Arrays;
+import java.util.LinkedList;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
@@ -50,11 +52,13 @@ class SwingUtils {
      *  The window containing the button.
      * @param buttonText
      *  The button's label.
+     * @param buttonTextAlternatives
+     *  Optionally the button's alternative labels.
      * @return
      *  true if the button was found;  false if the button was not found
      */
-    static boolean clickButton(final Window window, final String buttonText) {
-        final JButton button = findButton(window, buttonText);
+    static boolean clickButton(final Window window, final String buttonText, String... buttonTextAlternatives) {
+        final JButton button = findButton(window, buttonText, buttonTextAlternatives);
         if (button == null) return false;
 
         if (! button.isEnabled()) {
@@ -70,19 +74,23 @@ class SwingUtils {
 
     /**
      * Traverses a container hierarchy and returns the button with
-     * the given text.
+     * the given text or one of alternative texts
      * @param container
      *  the Container to search in
      * @param text
      *  the label of the button to be found
+     * @param textAlternatives
+     *  optionally alternative label of the button to be found
      * @return
      *  the button, if was found;  otherwise null
      */
-    static JButton findButton(Container container, String text) {
+    static JButton findButton(Container container, String text, String... textAlternatives) {
+        LinkedList<String> allAlternatives = new LinkedList<>(Arrays.asList(textAlternatives));
+        allAlternatives.addFirst(text);
         ComponentIterator iter = new ComponentIterator(container);
         while (iter.hasNext()) {
             Component component = iter.next();
-            if (component instanceof JButton && text.equals(((JButton)component).getText())) return (JButton)component;
+            if (component instanceof JButton && allAlternatives.contains(((JButton)component).getText())) return (JButton)component;
         }
         return null;
     }

--- a/src/ibcontroller/SwingUtils.java
+++ b/src/ibcontroller/SwingUtils.java
@@ -38,6 +38,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.JRadioButton;
 import javax.swing.JSeparator;
 import javax.swing.JTextField;
+import javax.swing.JToggleButton;
 import javax.swing.JTree;
 import javax.swing.MenuElement;
 import javax.swing.tree.TreeModel;
@@ -170,6 +171,25 @@ class SwingUtils {
         while (iter.hasNext()) {
             Component component = iter.next();
             if (component instanceof JRadioButton && text.equals(((JRadioButton)component).getText())) return (JRadioButton)component;
+        }
+        return null;
+    }
+
+    /**
+     * Traverses a container hierarchy and returns the toggle button with
+     * the given text
+     * @param container
+     *  the Container to search in
+     * @param text
+     *  the label of the button to be found
+     * @return
+     *  the toggle button, if was found;  otherwise null
+     */
+    static JToggleButton findToggleButton(Container container, String text) {
+        ComponentIterator iter = new ComponentIterator(container);
+        while (iter.hasNext()) {
+            Component component = iter.next();
+            if (component instanceof JToggleButton && text.equals(((JToggleButton)component).getText())) return (JToggleButton)component;
         }
         return null;
     }
@@ -510,6 +530,25 @@ class SwingUtils {
         if (rb.isSelected()) return true;
 
         rb.doClick();
+        return true;
+    }
+
+    /**
+     * Selects the specified JToggleButton.
+     * @param window
+     * the window in which to search for the required JToggleButton
+     * @param buttonText
+     * the label for the required JToggleButton
+     * @return
+     * true if the JToggleButton  was found; otherwise false
+     */
+    static boolean setToggleButtonSelected(Window window, String buttonText) {
+        final JToggleButton tb = findToggleButton(window, buttonText);
+        if (tb == null) return false;
+
+        if (tb.isSelected()) return true;
+
+        tb.doClick();
         return true;
     }
 


### PR DESCRIPTION
There were changes in TWS login dialog in version 974 which broke login functionality.
Label of login button was changed from **Login** to **Log In** (or **Paper Log In** for paper trading).
Component for choosing trading mode was changed from combo box to toggle buttons.

What has been done:

- add possibility to specify more button name alternatives for findButton / clickButton
- add login button alternatives **Log In**, **Paper Log In**
- add handling of toggle button trading mode chooser if combo box not found